### PR TITLE
remove UrlHelper section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,3 @@ Every request with `/site` prefix will be replaced:
 
 If you are using [expressive-skeleton](https://github.com/zendframework/zend-expressive-skeleton), you can copy `config/los-basepath.global.php.dist` to `config/autoload/los-basepath.global.php` and modify configuration as your needs.
 
-#### UrlHelper
-
-Zend Expressive comes with a UrlHelper that generates a url for your application, but we need to inject the new basePath.
-
-This modules comes with a UrlHelperFactory that does this job for you. Just add the following configuration:
-```php
-'dependencies' => [
-    'factories' => [
-        Zend\Expressive\Helper\UrlHelper::class => LosMiddleware\BasePath\UrlHelperFactory::class,
-        /* ... */
-    ],
-],
-``` 


### PR DESCRIPTION
I suggest you to remove UrlHelper section, since the LosMiddleware\BasePath\UrlHelperFactory was removed previously.I took some a time trying to understanding how I would use it because it was in the README.

Best regards,
Alexandre