### PR TITLE
Added instruction for dynamic base paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,21 @@ Every request with `/site` prefix will be replaced:
 /site/contact-us => /contact-us
 ```
 
+
 ### Zend Expressive
 
 If you are using [expressive-skeleton](https://github.com/zendframework/zend-expressive-skeleton), you can copy `config/los-basepath.global.php.dist` to `config/autoload/los-basepath.global.php` and modify configuration as your needs.
 
+### Dynamic base path
+
+In some cases a dynamic base path might be required. This can be achieved with the following code in your configuration file:
+
+```php
+$scriptPath = dirname($_SERVER['SCRIPT_NAME']);
+return [
+    // Use directory of script path if available, otherwise default to empty string.
+    'los_basepath' => strlen($scriptPath) > 1 ? $scriptPath : '',
+    
+    // rest of the configuration ...
+];
+```


### PR DESCRIPTION
It might be useful to add an instruction for using dynamic base paths. It depends on the root directory the project/application is in and has a failsave.

I am currently using this for my zend-expression app that is being tested on a deployment server and can be deployed to a location with a dynamic base path via CI without having to change the `config/autoload/los-basepath.global.php` file.